### PR TITLE
TG-21 fix tests for generator due to ACM init change

### DIFF
--- a/src/models/modules/acm.py
+++ b/src/models/modules/acm.py
@@ -11,12 +11,12 @@ from .conv_utils import conv2d
 class ACM(nn.Module):
     """Affine Combination Module from ManiGAN"""
 
-    def __init__(self, text_chans: int, img_chans: int, inner_dim: int = 64) -> None:
+    def __init__(self, img_chans: int, text_chans: int, inner_dim: int = 64) -> None:
         """
         Initialize the convolutional layers
 
-        :param int text_chans: Channels of textual input
         :param int img_chans: Channels in visual input
+        :param int text_chans: Channels of textual input
         :param int inner_dim: Hyperparameters for inner dimensionality of features
         """
         super().__init__()
@@ -28,7 +28,7 @@ class ACM(nn.Module):
         """
         Propagate the textual and visual input through the ACM module
 
-        :param torch.Tensor text: Textual input
+        :param torch.Tensor text: Textual input (can be hidden features)
         :param torch.Tensor img: Image input
         :return: Affine combination of text and image
         :rtype: torch.Tensor

--- a/src/models/modules/generator.py
+++ b/src/models/modules/generator.py
@@ -56,7 +56,7 @@ class InitStageG(nn.Module):
         )  # multiply channel by 3 because concat spatial and channel att
 
         self.residual = self._make_layer(ResidualBlock, ng // 8 * 3)
-        self.acm_module = ACM(ng // 8 * 3, self.gf_init)
+        self.acm_module = ACM(self.gf_init, ng // 8 * 3)
 
         self.spatial_att = SpatialAttention(self.text_dim, ng // 8)
         self.channel_att = ChannelWiseAttention(
@@ -155,7 +155,7 @@ class NextStageG(nn.Module):
 
         self.residual = self._make_layer(ResidualBlock, ng * 3)
         self.upsample = up_sample(ng * 3, ng)
-        self.acm_module = ACM(ng * 3, self.gf_init)
+        self.acm_module = ACM(self.gf_init, ng * 3)
         self.upsample2 = up_sample(ng, ng)
 
     def _make_layer(self, block: Any, channel_num: int) -> nn.Module:

--- a/tests/unit/acm_test.py
+++ b/tests/unit/acm_test.py
@@ -15,8 +15,8 @@ import pytest
 )
 def test_vanilla_acm(text_chans, img_chans, inner_dim, batch_dim, height, width):
     acm = ACM(
-        text_chans=text_chans,
         img_chans=img_chans,
+        text_chans=text_chans,
         inner_dim=inner_dim
     )
     text = torch.rand((batch_dim, text_chans, height, width))

--- a/tests/unit/generator_test.py
+++ b/tests/unit/generator_test.py
@@ -4,15 +4,15 @@ import torch
 
 import pytest
 
+
 @pytest.mark.parametrize(
     argnames=("batch", "Ng", "D", "conditioning_dim", "noise_dim", "L"),
     argvalues=(
-            (8, 32, 256, 100, 100, 18),
-            (16, 32, 256, 200, 50, 12),
-            (8, 32, 256, 50, 200, 14),
+            (8,  32, 16, 100, 100, 18),
+            (16, 32, 32, 200, 50,  12),
+            (8,  32, 15, 50,  200, 14),
     )
 )
-
 def test_generator(batch, Ng, D, conditioning_dim, noise_dim, L):
     generator = Generator(Ng, D, conditioning_dim, noise_dim)
     noise = torch.randn(batch, noise_dim)


### PR DESCRIPTION
- changed notation
- added extra phrase in the doc string
- had to change your tests a bit to comply with notation
- had to change your generator code to comply with notation
- also reduced your dims for testing generator because tensors got too big (32x256x100x100 is a lot to process in RAM)